### PR TITLE
Start porting to compile outside of image crate

### DIFF
--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -103,7 +103,12 @@ impl HuffmanTree {
     }
 
     /// Adds a symbol to a huffman tree
-    fn add_symbol(&mut self, symbol: u16, code: u16, code_length: u16) -> Result<(), DecodingError> {
+    fn add_symbol(
+        &mut self,
+        symbol: u16,
+        code: u16,
+        code_length: u16,
+    ) -> Result<(), DecodingError> {
         let mut node_index = 0;
         let code = usize::from(code);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 //! Decoding and Encoding of WebP Images
 
+#![forbid(unsafe_code)]
+
 pub use self::decoder::WebPDecoder;
 
 mod decoder;

--- a/src/loop_filter.rs
+++ b/src/loop_filter.rs
@@ -1,10 +1,8 @@
 //! Does loop filtering on webp lossy images
 
-use crate::utils::clamp;
-
 #[inline]
 fn c(val: i32) -> i32 {
-    clamp(val, -128, 127)
+    num_traits::clamp(val, -128, 127)
 }
 
 //unsigned to signed

--- a/src/lossless_transform.rs
+++ b/src/lossless_transform.rs
@@ -1,8 +1,9 @@
 use std::convert::TryFrom;
 use std::convert::TryInto;
 
+use crate::decoder::DecodingError;
+
 use super::lossless::subsample_size;
-use super::lossless::DecoderError;
 
 #[derive(Debug, Clone)]
 pub(crate) enum TransformType {
@@ -28,7 +29,7 @@ impl TransformType {
         image_data: &mut Vec<u32>,
         width: u16,
         height: u16,
-    ) -> Result<(), DecoderError> {
+    ) -> Result<(), DecodingError> {
         match self {
             TransformType::PredictorTransform {
                 size_bits,
@@ -39,7 +40,7 @@ impl TransformType {
                 let height = usize::from(height);
 
                 if image_data.len() < width * height {
-                    return Err(DecoderError::TransformError);
+                    return Err(DecodingError::TransformError);
                 }
 
                 //handle top and left borders specially


### PR DESCRIPTION
This is mostly done, but the handling of animation still references and relies on types from the main `image` crate.