### PR TITLE
Avoid bounds checks in IDCD and IWHT

### DIFF
--- a/src/transform.rs
+++ b/src/transform.rs
@@ -7,6 +7,9 @@ pub(crate) fn idct4x4(block: &mut [i32]) {
         i64::from(block[idx])
     }
 
+    // Perform one lenght check up front to avoid subsequent bounds checks in this function
+    assert!(block.len() >= 16);
+
     for i in 0usize..4 {
         let a1 = fetch(block, i) + fetch(block, 8 + i);
         let b1 = fetch(block, i) - fetch(block, 8 + i);
@@ -46,6 +49,9 @@ pub(crate) fn idct4x4(block: &mut [i32]) {
 
 // 14.3
 pub(crate) fn iwht4x4(block: &mut [i32]) {
+    // Perform one lenght check up front to avoid subsequent bounds checks in this function
+    assert!(block.len() >= 16);
+
     for i in 0usize..4 {
         let a1 = block[i] + block[12 + i];
         let b1 = block[4 + i] + block[8 + i];

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -49,7 +49,7 @@ pub(crate) fn idct4x4(block: &mut [i32]) {
 
 // 14.3
 pub(crate) fn iwht4x4(block: &mut [i32]) {
-    // Perform one lenght check up front to avoid subsequent bounds checks in this function
+    // Perform one length check up front to avoid subsequent bounds checks in this function
     assert!(block.len() >= 16);
 
     for i in 0usize..4 {


### PR DESCRIPTION
Before: https://godbolt.org/z/PTo583Y7o

After: https://godbolt.org/z/qdda8sxsr

No autovectorization, but at least the bounds checks are gone.