### PR TITLE
Limit max memory allocation by fuzz target

### DIFF
--- a/fuzz/fuzz_targets/decode_still.rs
+++ b/fuzz/fuzz_targets/decode_still.rs
@@ -8,7 +8,10 @@ fuzz_target!(|input: &[u8]| {
     if let Ok(mut decoder) = decoder {
         let (width, height) = decoder.dimensions();
         let bytes_per_pixel = if decoder.has_alpha() { 4 } else { 3 };
-        let mut data = vec![0; width as usize * height as usize * bytes_per_pixel];
-        let _ = decoder.read_image(&mut data);
+        let total_bytes = width as usize * height as usize * bytes_per_pixel;
+        if total_bytes <= 1024 * 1024 * 1024 {
+            let mut data = vec![0; total_bytes];
+            let _ = decoder.read_image(&mut data);
+        }
     }
 });


### PR DESCRIPTION
With this patch, running with `cargo fuzz run decode_still -- -rss_limit_mb=5000`, and seeded on [AFL's webp corpus](https://lcamtuf.coredump.cx/afl/demo/), I see no fuzzing failures after 40M iterations.

(Maximum resident set size reaches only 2369 MB, so a lower limited could also have been used.)

Resolves #22