### PR TITLE
Initial fuzzing harness for animated images

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,3 +25,10 @@ name = "decode_still"
 path = "fuzz_targets/decode_still.rs"
 test = false
 doc = false
+
+
+[[bin]]
+name = "decode_animated"
+path = "fuzz_targets/decode_animated.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/decode_animated.rs
+++ b/fuzz/fuzz_targets/decode_animated.rs
@@ -1,0 +1,19 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
+
+fuzz_target!(|input: &[u8]| {
+    let decoder = webp::WebPDecoder::new(Cursor::new(input));
+    if let Ok(mut decoder) = decoder {
+        let (width, height) = decoder.dimensions();
+        let bytes_per_pixel = if decoder.has_alpha() { 4 } else { 3 };
+        let total_bytes = width as usize * height as usize * bytes_per_pixel;
+        if total_bytes <= 1024 * 1024 * 1024 {
+            if decoder.has_animation() {
+                let mut data = vec![0; total_bytes];
+                while let Ok(_delay) = decoder.read_frame(&mut data) {};
+            }
+        }
+    }
+});


### PR DESCRIPTION
Animated images with the "loop forever" flag currently cause an infinite loop in the decoder.

The AFL seed images didn't seem to contain any animated ones, so I made these seed images myself from [the sample image linked from the official Google documentation](https://developers.google.com/speed/webp/faq#why_should_i_use_animated_webp): [webp_animated_fuzz_seeds.tar.gz](https://github.com/image-rs/image-webp/files/13779350/webp_animated_fuzz_seeds.tar.gz)

Resolves (?) #31