### PR TITLE
Validate size of uncompressed alpha chunks

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,15 +48,6 @@ dependencies = [
  "arbitrary",
  "cc",
  "once_cell",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -131,7 +116,6 @@ name = "webp"
 version = "0.1.0"
 dependencies = [
  "byteorder",
- "num-traits",
  "thiserror",
 ]
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -691,7 +691,8 @@ impl<R: Read + Seek> WebPDecoder<R> {
                 // read alpha
                 let next_chunk_start = self.r.stream_position()? + chunk_size_rounded as u64;
                 let mut reader = (&mut self.r).take(chunk_size as u64);
-                let alpha_chunk = read_alpha_chunk(&mut reader, frame_width as u16, frame_height as u16)?;
+                let alpha_chunk =
+                    read_alpha_chunk(&mut reader, frame_width as u16, frame_height as u16)?;
 
                 // read opaque
                 self.r.seek(io::SeekFrom::Start(next_chunk_start))?;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -571,8 +571,8 @@ impl<R: Read + Seek> WebPDecoder<R> {
                     .clone();
                 let alpha_chunk = read_alpha_chunk(
                     &mut range_reader(&mut self.r, range.start..range.end)?,
-                    self.width,
-                    self.height,
+                    self.width as u16,
+                    self.height as u16,
                 )?;
 
                 for y in 0..frame.height {
@@ -632,6 +632,9 @@ impl<R: Read + Seek> WebPDecoder<R> {
         let frame_y = extended::read_3_bytes(&mut self.r)? * 2;
         let frame_width = extended::read_3_bytes(&mut self.r)? + 1;
         let frame_height = extended::read_3_bytes(&mut self.r)? + 1;
+        if frame_width > 16384 || frame_height > 16384 {
+            return Err(DecodingError::ImageTooLarge);
+        }
         if frame_x + frame_width > self.width || frame_y + frame_height > self.height {
             return Err(DecodingError::FrameOutsideImage);
         }
@@ -688,7 +691,7 @@ impl<R: Read + Seek> WebPDecoder<R> {
                 // read alpha
                 let next_chunk_start = self.r.stream_position()? + chunk_size_rounded as u64;
                 let mut reader = (&mut self.r).take(chunk_size as u64);
-                let alpha_chunk = read_alpha_chunk(&mut reader, frame_width, frame_height)?;
+                let alpha_chunk = read_alpha_chunk(&mut reader, frame_width as u16, frame_height as u16)?;
 
                 // read opaque
                 self.r.seek(io::SeekFrom::Start(next_chunk_start))?;

--- a/src/lossless.rs
+++ b/src/lossless.rs
@@ -236,7 +236,7 @@ impl<R: Read> LosslessDecoder<R> {
     }
 
     /// Adjusts the color map since it's subtraction coded
-    fn adjust_color_map(color_map: &mut Vec<u32>) {
+    fn adjust_color_map(color_map: &mut [u32]) {
         for i in 1..color_map.len() {
             color_map[i] = add_pixels(color_map[i], color_map[i - 1]);
         }

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -1307,7 +1307,7 @@ impl<R: Read> Vp8Decoder<R> {
 
             self.top = init_top_macroblocks(self.frame.width as usize);
             // Almost always the first macro block, except when non exists (i.e. `width == 0`)
-            self.left = self.top.get(0).cloned().unwrap_or_default();
+            self.left = self.top.first().cloned().unwrap_or_default();
 
             self.mbwidth = (self.frame.width + 15) / 16;
             self.mbheight = (self.frame.height + 15) / 16;


### PR DESCRIPTION
Using read_exact to load uncompressed alpha chunks prevents overly short chunks from giving us inconsistent dimensions.

Also adjusts some arguments to reflect that frames larger than 16384x16384 are not allowed by the spec (these would have been caught later when the VP8 / VP8L chunk failed to decode due to inconsistent dimensions).