### PR TITLE
Update animated fuzzing harness to the latest API

### DIFF
--- a/fuzz/fuzz_targets/decode_animated.rs
+++ b/fuzz/fuzz_targets/decode_animated.rs
@@ -10,7 +10,7 @@ fuzz_target!(|input: &[u8]| {
         let bytes_per_pixel = if decoder.has_alpha() { 4 } else { 3 };
         let total_bytes = width as usize * height as usize * bytes_per_pixel;
         if total_bytes <= 1024 * 1024 * 1024 {
-            if decoder.has_animation() {
+            if decoder.is_animated() {
                 let mut data = vec![0; total_bytes];
                 while let Ok(_delay) = decoder.read_frame(&mut data) {};
             }


### PR DESCRIPTION
Still loops infinitely (?) or at least for over a minute on this input: [timeout-c21d668c07f7c336a3284ad6b36f7bfaac27138c.webp.gz](https://github.com/image-rs/image-webp/files/13806024/timeout-c21d668c07f7c336a3284ad6b36f7bfaac27138c.webp.gz)
