### PR TITLE
Use a table-based Huffman decoder

### DIFF
--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -151,10 +151,19 @@ impl HuffmanTree {
             }
         }
 
-        let mut tree = HuffmanTree::init(num_symbols)?;
+        if num_symbols == 0 {
+            return Err(DecodingError::HuffmanError);
+        }
+
+        let max_nodes = 2 * num_symbols - 1;
+        let mut tree = HuffmanTree {
+            tree: vec![HuffmanTreeNode::Empty; max_nodes],
+            max_nodes,
+            num_nodes: 1,
+        };
 
         if num_symbols == 1 {
-            tree.add_symbol(root_symbol, 0, 0)?;
+            return Ok(Self::build_single_node(root_symbol));
         } else {
             let codes = HuffmanTree::code_lengths_to_codes(&code_lengths)?;
 
@@ -168,19 +177,17 @@ impl HuffmanTree {
         Ok(tree)
     }
 
-    /// Builds a tree explicitly from lengths, codes and symbols
-    pub(crate) fn build_explicit(
-        code_lengths: Vec<u16>,
-        codes: Vec<u16>,
-        symbols: Vec<u16>,
-    ) -> Result<HuffmanTree, DecodingError> {
-        let mut tree = HuffmanTree::init(symbols.len())?;
+    pub(crate) fn build_single_node(symbol: u16) -> HuffmanTree {
+        let mut tree = HuffmanTree::init(1).unwrap();
+        tree.add_symbol(symbol, 0, 0).unwrap();
+        tree
+    }
 
-        for i in 0..symbols.len() {
-            tree.add_symbol(symbols[i], codes[i], code_lengths[i])?;
-        }
-
-        Ok(tree)
+    pub(crate) fn build_two_node(zero: u16, one: u16) -> HuffmanTree {
+        let mut tree = HuffmanTree::init(2).unwrap();
+        tree.add_symbol(zero, 0, 1).unwrap();
+        tree.add_symbol(one, 1, 1).unwrap();
+        tree
     }
 
     pub(crate) fn is_single_node(&self) -> bool {

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -17,9 +17,8 @@ enum HuffmanTreeNode {
     Empty,
 }
 
-/// Huffman tree
 #[derive(Clone, Debug)]
-pub(crate) enum HuffmanTree {
+enum HuffmanTreeInner {
     Single(u16),
     Tree {
         tree: Vec<HuffmanTreeNode>,
@@ -28,9 +27,13 @@ pub(crate) enum HuffmanTree {
     },
 }
 
+/// Huffman tree
+#[derive(Clone, Debug)]
+pub(crate) struct HuffmanTree(HuffmanTreeInner);
+
 impl Default for HuffmanTree {
     fn default() -> Self {
-        HuffmanTree::Single(0)
+        Self(HuffmanTreeInner::Single(0))
     }
 }
 
@@ -153,19 +156,19 @@ impl HuffmanTree {
             }
         }
 
-        Ok(HuffmanTree::Tree {
+        Ok(Self(HuffmanTreeInner::Tree {
             tree,
             table,
             table_mask,
-        })
+        }))
     }
 
     pub(crate) fn build_single_node(symbol: u16) -> HuffmanTree {
-        HuffmanTree::Single(symbol)
+        Self(HuffmanTreeInner::Single(symbol))
     }
 
     pub(crate) fn build_two_node(zero: u16, one: u16) -> HuffmanTree {
-        HuffmanTree::Tree {
+        Self(HuffmanTreeInner::Tree {
             tree: vec![
                 HuffmanTreeNode::Leaf(zero),
                 HuffmanTreeNode::Leaf(one),
@@ -173,11 +176,11 @@ impl HuffmanTree {
             ],
             table: vec![1 << 16 | zero as u32, 1 << 16 | one as u32],
             table_mask: 0x1,
-        }
+        })
     }
 
     pub(crate) fn is_single_node(&self) -> bool {
-        matches!(self, HuffmanTree::Single(_))
+        matches!(self.0, HuffmanTreeInner::Single(_))
     }
 
     #[inline(never)]
@@ -212,8 +215,8 @@ impl HuffmanTree {
         &self,
         bit_reader: &mut BitReader<R>,
     ) -> Result<u16, DecodingError> {
-        match self {
-            HuffmanTree::Tree {
+        match &self.0 {
+            HuffmanTreeInner::Tree {
                 tree,
                 table,
                 table_mask,
@@ -227,7 +230,7 @@ impl HuffmanTree {
 
                 Self::read_symbol_slowpath(tree, v as usize, bit_reader)
             }
-            HuffmanTree::Single(symbol) => Ok(*symbol),
+            HuffmanTreeInner::Single(symbol) => Ok(*symbol),
         }
     }
 }

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -103,7 +103,7 @@ impl HuffmanTree {
         let mut table = vec![0; table_size];
         for (symbol, (&code, &length)) in huff_codes.iter().zip(code_lengths.iter()).enumerate() {
             if length != 0 && length <= table_bits {
-                let mut j = ((code as u16).reverse_bits() >> (16 - length)) as usize;
+                let mut j = (u16::reverse_bits(code) >> (16 - length)) as usize;
                 let entry = ((length as u32) << 16) | symbol as u32;
                 while j < table_size {
                     table[j] = entry;

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -26,19 +26,6 @@ pub(crate) struct HuffmanTree {
 }
 
 impl HuffmanTree {
-    fn is_full(&self) -> bool {
-        self.num_nodes == self.max_nodes
-    }
-
-    /// Turns a node from empty into a branch and assigns its children
-    fn assign_children(&mut self, node_index: usize) -> usize {
-        let offset_index = self.num_nodes - node_index;
-        self.tree[node_index] = HuffmanTreeNode::Branch(offset_index);
-        self.num_nodes += 2;
-
-        offset_index
-    }
-
     /// Init a huffman tree
     fn init(num_leaves: usize) -> Result<HuffmanTree, DecodingError> {
         if num_leaves == 0 {
@@ -126,10 +113,15 @@ impl HuffmanTree {
 
             let offset = match node {
                 HuffmanTreeNode::Empty => {
-                    if self.is_full() {
+                    if self.num_nodes == self.max_nodes {
                         return Err(DecodingError::HuffmanError);
                     }
-                    self.assign_children(node_index)
+
+                    // Turns a node from empty into a branch and assigns its children
+                    let offset_index = self.num_nodes - node_index;
+                    self.tree[node_index] = HuffmanTreeNode::Branch(offset_index);
+                    self.num_nodes += 2;
+                    offset_index
                 }
                 HuffmanTreeNode::Leaf(_) => return Err(DecodingError::HuffmanError),
                 HuffmanTreeNode::Branch(offset) => offset,

--- a/src/lossless.rs
+++ b/src/lossless.rs
@@ -749,6 +749,11 @@ impl<R: Read> BitReader<R> {
         self.buffer & ((1 << num) - 1)
     }
 
+    /// Peeks at the full buffer.
+    pub(crate) fn peek_full(&self) -> u64 {
+        self.buffer
+    }
+
     /// Consumes `num` bits from the buffer returning an error if there are not enough bits.
     pub(crate) fn consume(&mut self, num: u8) -> Result<(), DecodingError> {
         if self.nbits < num {


### PR DESCRIPTION
This substantially improves decoding performance, sometimes by more than a factor of two

Fixes #55 