### PR TITLE
Bump MSRV to 1.80

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.67.1", nightly, beta, stable]
+        rust: ["1.80.1", nightly, beta, stable]
     steps:
     - uses: actions/checkout@v4
 
     - uses: dtolnay/rust-toolchain@nightly
-      if: ${{ matrix.rust == '1.67.1' }}
+      if: ${{ matrix.rust == '1.80.1' }}
     - name: Generate Cargo.lock with minimal-version dependencies
-      if: ${{ matrix.rust == '1.67.1' }}
+      if: ${{ matrix.rust == '1.80.1' }}
       run: cargo -Zminimal-versions generate-lockfile
 
     - uses: dtolnay/rust-toolchain@v1
@@ -34,7 +34,7 @@ jobs:
     - name: build
       run: cargo build -v
     - name: test
-      if: ${{ matrix.rust != '1.67.1' }}
+      if: ${{ matrix.rust != '1.80.1' }}
       run: cargo test -v && cargo doc -v
     - name: bench
       if: ${{ matrix.rust == 'nightly' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "image-webp"
 version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.67.1"
+rust-version = "1.80.1"
 
 description = "WebP encoding and decoding in pure Rust"
 homepage = "https://github.com/image-rs/image-webp"

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -286,7 +286,7 @@ fn write_huffman_tree<W: Write>(
 
 const fn length_to_symbol(len: u16) -> (u16, u8) {
     let len = len - 1;
-    let highest_bit = 15 - len.leading_zeros() as u16; // TODO: use ilog2 once MSRV >= 1.67
+    let highest_bit = len.ilog2() as u16;
     let second_highest_bit = (len >> (highest_bit - 1)) & 1;
     let extra_bits = highest_bit - 1;
     let symbol = 2 * highest_bit + second_highest_bit;

--- a/src/lossless_transform.rs
+++ b/src/lossless_transform.rs
@@ -386,17 +386,6 @@ pub(crate) fn apply_color_indexing_transform(
     table_size: u16,
     table_data: &[u8],
 ) {
-    // TODO: Replace with built-in div_ceil when MSRV is 1.73+
-    const fn div_ceil(a: u16, b: u16) -> u16 {
-        let d = a / b;
-        let r = a % b;
-        if r > 0 && b > 0 {
-            d + 1
-        } else {
-            d
-        }
-    }
-
     if table_size > 16 {
         let mut table = table_data.chunks_exact(4).collect::<Vec<_>>();
         table.resize(256, &[0; 4]);
@@ -434,7 +423,7 @@ pub(crate) fn apply_color_indexing_transform(
         let table = table.chunks_exact(4 << width_bits).collect::<Vec<_>>();
 
         let entry_size = 4 << width_bits;
-        let index_image_width = div_ceil(width, 1 << width_bits) as usize;
+        let index_image_width = width.div_ceil(1 << width_bits) as usize;
         let final_entry_size = width as usize * 4 - entry_size * (index_image_width - 1);
 
         for y in (0..height as usize).rev() {


### PR DESCRIPTION
Track a couple changes we'll want to do in the next MSRV. Leaving this as draft because it'll be a while before 1.80 is old enough for us to drop support for older versions