### PR TITLE
Require BufRead

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -2,7 +2,7 @@ use byteorder_lite::{LittleEndian, ReadBytesExt};
 use quick_error::quick_error;
 
 use std::collections::HashMap;
-use std::io::{self, BufReader, Cursor, Read, Seek};
+use std::io::{self, BufRead, BufReader, Cursor, Read, Seek};
 use std::num::NonZeroU16;
 use std::ops::Range;
 
@@ -276,7 +276,7 @@ pub struct WebPDecoder<R> {
     chunks: HashMap<WebPRiffChunk, Range<u64>>,
 }
 
-impl<R: Read + Seek> WebPDecoder<R> {
+impl<R: BufRead + Seek> WebPDecoder<R> {
     /// Create a new WebPDecoder from the reader `r`. The decoder performs many small reads, so the
     /// reader should be buffered.
     pub fn new(r: R) -> Result<WebPDecoder<R>, DecodingError> {
@@ -849,10 +849,10 @@ impl<R: Read + Seek> WebPDecoder<R> {
     }
 }
 
-pub(crate) fn range_reader<R: Read + Seek>(
+pub(crate) fn range_reader<R: BufRead + Seek>(
     mut r: R,
     range: Range<u64>,
-) -> Result<impl Read, DecodingError> {
+) -> Result<impl BufRead, DecodingError> {
     r.seek(io::SeekFrom::Start(range.start))?;
     Ok(r.take(range.end - range.start))
 }

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -1,7 +1,7 @@
 use super::lossless::LosslessDecoder;
 use crate::decoder::DecodingError;
 use byteorder_lite::ReadBytesExt;
-use std::io::Read;
+use std::io::{BufRead, Read};
 
 #[derive(Debug, Clone)]
 pub(crate) struct WebPExtendedInfo {
@@ -264,7 +264,7 @@ pub(crate) enum FilteringMethod {
     Gradient,
 }
 
-pub(crate) fn read_alpha_chunk<R: Read>(
+pub(crate) fn read_alpha_chunk<R: BufRead>(
     reader: &mut R,
     width: u16,
     height: u16,

--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::BufRead;
 
 use crate::decoder::DecodingError;
 
@@ -184,7 +184,7 @@ impl HuffmanTree {
     }
 
     #[inline(never)]
-    fn read_symbol_slowpath<R: Read>(
+    fn read_symbol_slowpath<R: BufRead>(
         tree: &[HuffmanTreeNode],
         mut v: usize,
         bit_reader: &mut BitReader<R>,
@@ -211,7 +211,7 @@ impl HuffmanTree {
     ///
     /// You must call call `bit_reader.fill()` before calling this function or it may erroroneosly
     /// detect the end of the stream and return a bitstream error.
-    pub(crate) fn read_symbol<R: Read>(
+    pub(crate) fn read_symbol<R: BufRead>(
         &self,
         bit_reader: &mut BitReader<R>,
     ) -> Result<u16, DecodingError> {


### PR DESCRIPTION
Requiring that the provided reader implements `BufRead` enables a much more efficient bit reader implementation. This is a breaking change, but yields a 15-25% end-to-end performance improvement