### PR TITLE
Fix wrong frame compositing logic

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -812,7 +812,9 @@ impl<R: BufRead + Seek> WebPDecoder<R> {
         if self.animation.canvas.is_none() {
             self.animation.canvas = {
                 let mut canvas = vec![0; (self.width * self.height * 4) as usize];
-                canvas.chunks_exact_mut(4).for_each(|c| c.copy_from_slice(&info.background_color));
+                canvas
+                    .chunks_exact_mut(4)
+                    .for_each(|c| c.copy_from_slice(&info.background_color));
                 Some(canvas)
             }
         }

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -20,8 +20,8 @@ pub(crate) struct WebPExtendedInfo {
 
 /// Composites a frame onto a canvas.
 ///
-/// Starts by filling the canvas with the background color, if provided. Then copies or blends the
-/// frame onto the canvas.
+/// Starts by filling the rectangle occupied by the previous frame with the background
+/// color, if provided. Then copies or blends the frame onto the canvas.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn composite_frame(
     canvas: &mut [u8],
@@ -35,13 +35,17 @@ pub(crate) fn composite_frame(
     frame_height: u32,
     frame_has_alpha: bool,
     frame_use_alpha_blending: bool,
+    previous_frame_width: u32,
+    previous_frame_height: u32,
+    previous_frame_offset_x: u32,
+    previous_frame_offset_y: u32,
 ) {
-    if frame_offset_x == 0
+    let frame_is_full_size = frame_offset_x == 0
         && frame_offset_y == 0
         && frame_width == canvas_width
-        && frame_height == canvas_height
-        && !frame_use_alpha_blending
-    {
+        && frame_height == canvas_height;
+
+    if frame_is_full_size && !frame_use_alpha_blending {
         if frame_has_alpha {
             canvas.copy_from_slice(frame);
         } else {
@@ -53,15 +57,44 @@ pub(crate) fn composite_frame(
         return;
     }
 
+    // clear rectangle occupied by previous frame
     if let Some(clear_color) = clear_color {
-        if frame_has_alpha {
-            for pixel in canvas.chunks_exact_mut(4) {
-                pixel.copy_from_slice(&clear_color);
-            }
-        } else {
-            for pixel in canvas.chunks_exact_mut(3) {
-                pixel.copy_from_slice(&clear_color[..3]);
-            }
+        match (frame_is_full_size, frame_has_alpha) {
+            (true, true) => {
+                for pixel in canvas.chunks_exact_mut(4) {
+                    pixel.copy_from_slice(&clear_color);
+                }
+            },
+            (true, false) => {
+                for pixel in canvas.chunks_exact_mut(3) {
+                    pixel.copy_from_slice(&clear_color[..3]);
+                }
+            },
+            (false, true) => {
+                for y in 0..previous_frame_height as usize {
+                    for x in 0..previous_frame_width as usize {
+                        let canvas_index = ((x + previous_frame_offset_x as usize)
+                            + (y + previous_frame_offset_y as usize) * canvas_width as usize)
+                            * 4;
+
+                        let output = &mut canvas[canvas_index..][..4];
+                        output.copy_from_slice(&clear_color);
+                    }
+                }
+            },
+            (false, false) => {
+                for y in 0..previous_frame_height as usize {
+                    for x in 0..previous_frame_width as usize {
+                        // let frame_index = (x + y * frame_width as usize) * 4;
+                        let canvas_index = ((x + previous_frame_offset_x as usize)
+                            + (y + previous_frame_offset_y as usize) * canvas_width as usize)
+                            * 3;
+
+                        let output = &mut canvas[canvas_index..][..3];
+                        output.copy_from_slice(&clear_color[..3]);
+                    }
+                }
+            },
         }
     }
 

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -64,12 +64,12 @@ pub(crate) fn composite_frame(
                 for pixel in canvas.chunks_exact_mut(4) {
                     pixel.copy_from_slice(&clear_color);
                 }
-            },
+            }
             (true, false) => {
                 for pixel in canvas.chunks_exact_mut(3) {
                     pixel.copy_from_slice(&clear_color[..3]);
                 }
-            },
+            }
             (false, true) => {
                 for y in 0..previous_frame_height as usize {
                     for x in 0..previous_frame_width as usize {
@@ -81,7 +81,7 @@ pub(crate) fn composite_frame(
                         output.copy_from_slice(&clear_color);
                     }
                 }
-            },
+            }
             (false, false) => {
                 for y in 0..previous_frame_height as usize {
                     for x in 0..previous_frame_width as usize {
@@ -94,7 +94,7 @@ pub(crate) fn composite_frame(
                         output.copy_from_slice(&clear_color[..3]);
                     }
                 }
-            },
+            }
         }
     }
 


### PR DESCRIPTION
previously, the canvas was completely cleared, using the background color, before compositing the current frame on it. this PR corrects that, instead only clearing the rectangle that was occupied by the frame before the one being composited, if it had requested to be disposed of.

along with #85, this PR fixes image-rs/image#2320 and produces the following gif, when using the same code snippet and gif provided: 
![derpy_cloud_right](https://github.com/user-attachments/assets/953b1340-bdf5-452a-afc7-2c9aea4201c9)

i'm not entirely sure, however, when the background color provided in the ANIM frame should be used, as this library still produces results that are different from web browsers and other image viewing programs, that seem to just assume a fully transparent bg color in all cases (or maybe only when the animated webp is transparent?)