### PR TITLE
Eliminate bounds checks in `read_coefficients()` (for zero performance gain?)

### DIFF
--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -1658,6 +1658,7 @@ impl<R: Read> Vp8Decoder<R> {
         // perform bounds checks once up front,
         // so that the compiler doesn't have to insert them in the hot loop below
         let block = &mut block[..16];
+        assert!(complexity <= 2);
 
         let first = if plane == 0 { 1usize } else { 0usize };
         let probs = &self.token_probs[plane];
@@ -1668,7 +1669,7 @@ impl<R: Read> Vp8Decoder<R> {
         let mut skip = false;
 
         for i in first..16usize {
-            let table = &probs[COEFF_BANDS[i] as usize][complexity];
+            let table = &probs[(COEFF_BANDS[i] % 8) as usize][complexity];
 
             let token = if !skip {
                 self.partitions[p].read_with_tree(tree, table, 0)?

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -1645,7 +1645,6 @@ impl<R: Read> Vp8Decoder<R> {
         }
     }
 
-    #[inline(never)]
     fn read_coefficients(
         &mut self,
         block: &mut [i32],

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -1669,6 +1669,8 @@ impl<R: Read> Vp8Decoder<R> {
         let mut skip = false;
 
         for i in first..16usize {
+            // `% 8` is added to eliminate a bounds check.
+            // as of rustc 1.82 it's not smart enough to realize all the constant indices are below 8.
             let table = &probs[(COEFF_BANDS[i] % 8) as usize][complexity];
 
             let token = if !skip {
@@ -1720,8 +1722,7 @@ impl<R: Read> Vp8Decoder<R> {
                 abs_value = -abs_value;
             }
 
-            // % 16 is added to eliminate a bounds check.
-            // as of rustc 1.82 it's not smart enough to realize all the constant indices are below 16.
+            // % 16 is added to eliminate a bounds check. Same as above.
             block[(ZIGZAG[i] % 16) as usize] =
                 abs_value * i32::from(if ZIGZAG[i] > 0 { acq } else { dcq });
 

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -1663,6 +1663,7 @@ impl<R: Read> Vp8Decoder<R> {
         let first = if plane == 0 { 1usize } else { 0usize };
         let probs = &self.token_probs[plane];
         let tree = &DCT_TOKEN_TREE;
+        let reader = &mut self.partitions[p];
 
         let mut complexity = complexity;
         let mut has_coefficients = false;
@@ -1674,9 +1675,9 @@ impl<R: Read> Vp8Decoder<R> {
             let table = &probs[(COEFF_BANDS[i] % 8) as usize][complexity];
 
             let token = if !skip {
-                self.partitions[p].read_with_tree(tree, table, 0)?
+                reader.read_with_tree(tree, table, 0)?
             } else {
-                self.partitions[p].read_with_tree(tree, table, 2)?
+                reader.read_with_tree(tree, table, 2)?
             };
 
             let mut abs_value = i32::from(match token {
@@ -1698,7 +1699,7 @@ impl<R: Read> Vp8Decoder<R> {
                     let mut j = 0;
 
                     while t[j] > 0 {
-                        extra = extra + extra + self.partitions[p].read_bool(t[j])? as i16;
+                        extra = extra + extra + reader.read_bool(t[j])? as i16;
                         j += 1;
                     }
 
@@ -1718,7 +1719,7 @@ impl<R: Read> Vp8Decoder<R> {
                 2
             };
 
-            if self.partitions[p].read_bool(128)? {
+            if reader.read_bool(128)? {
                 abs_value = -abs_value;
             }
 

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -1669,9 +1669,7 @@ impl<R: Read> Vp8Decoder<R> {
         let mut skip = false;
 
         for i in first..16usize {
-            // `% 8` is added to eliminate a bounds check.
-            // as of rustc 1.82 it's not smart enough to realize all the constant indices are below 8.
-            let table = &probs[(COEFF_BANDS[i] % 8) as usize][complexity];
+            let table = &probs[COEFF_BANDS[i] as usize][complexity];
 
             let token = if !skip {
                 reader.read_with_tree(tree, table, 0)?
@@ -1723,8 +1721,7 @@ impl<R: Read> Vp8Decoder<R> {
                 abs_value = -abs_value;
             }
 
-            // % 16 is added to eliminate a bounds check. Same as above.
-            block[(ZIGZAG[i] % 16) as usize] =
+            block[ZIGZAG[i] as usize] =
                 abs_value * i32::from(if ZIGZAG[i] > 0 { acq } else { dcq });
 
             has_coefficients = true;

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -1692,14 +1692,15 @@ impl<R: Read> Vp8Decoder<R> {
                 literal @ DCT_1..=DCT_4 => i16::from(literal),
 
                 category @ DCT_CAT1..=DCT_CAT6 => {
-                    let t = PROB_DCT_CAT[(category - DCT_CAT1) as usize];
+                    let probs = PROB_DCT_CAT[(category - DCT_CAT1) as usize];
 
                     let mut extra = 0i16;
-                    let mut j = 0;
 
-                    while t[j] > 0 {
-                        extra = extra + extra + reader.read_bool(t[j])? as i16;
-                        j += 1;
+                    for t in probs.iter().copied() {
+                        if t == 0 {
+                            break;
+                        }
+                        extra = extra + extra + reader.read_bool(t)? as i16;
                     }
 
                     i16::from(DCT_CAT_BASE[(category - DCT_CAT1) as usize]) + extra

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -1647,7 +1647,7 @@ impl<R: Read> Vp8Decoder<R> {
 
     fn read_coefficients(
         &mut self,
-        block: &mut [i32],
+        block: &mut [i32; 16],
         p: usize,
         plane: usize,
         complexity: usize,
@@ -1656,7 +1656,6 @@ impl<R: Read> Vp8Decoder<R> {
     ) -> Result<bool, DecodingError> {
         // perform bounds checks once up front,
         // so that the compiler doesn't have to insert them in the hot loop below
-        let block = &mut block[..16];
         assert!(complexity <= 2);
 
         let first = if plane == 0 { 1usize } else { 0usize };
@@ -1763,7 +1762,8 @@ impl<R: Read> Vp8Decoder<R> {
             let mut left = self.left.complexity[y + 1];
             for x in 0usize..4 {
                 let i = x + y * 4;
-                let block = &mut blocks[i * 16..i * 16 + 16];
+                let block = &mut blocks[i * 16..][..16];
+                let block: &mut [i32; 16] = block.try_into().unwrap();
 
                 let complexity = self.top[mbx].complexity[x + 1] + left;
                 let dcq = self.segment[sindex].ydc;
@@ -1790,7 +1790,8 @@ impl<R: Read> Vp8Decoder<R> {
 
                 for x in 0usize..2 {
                     let i = x + y * 2 + if j == 5 { 16 } else { 20 };
-                    let block = &mut blocks[i * 16..i * 16 + 16];
+                    let block = &mut blocks[i * 16..][..16];
+                    let block: &mut [i32; 16] = block.try_into().unwrap();
 
                     let complexity = self.top[mbx].complexity[x + j] + left;
                     let dcq = self.segment[sindex].uvdc;


### PR DESCRIPTION
This PR removes all bounds checks from the hot loop of `read_coefficients()`. Workshopped by staring at the assembly using `cargo-show-asm` on baseline x86_64.

This function's execution (excluding other functions it calls) accounts for 20% of the time on the profile from #71. Despite that, I could not measure any difference in end-to-end performance on my machine. So feel free to reject this PR.