### PR TITLE
Faster YUV -> RGBA conversion

### DIFF
--- a/src/huffman.rs
+++ b/src/huffman.rs
@@ -1,12 +1,11 @@
+//! Rudimentary utility for reading Canonical Huffman Codes.
+//! Based off https://github.com/webmproject/libwebp/blob/7f8472a610b61ec780ef0a8873cd954ac512a505/src/utils/huffman.c
+
 use std::io::BufRead;
 
 use crate::decoder::DecodingError;
 
 use super::lossless::BitReader;
-
-/// Rudimentary utility for reading Canonical Huffman Codes.
-/// Based off https://github.com/webmproject/libwebp/blob/7f8472a610b61ec780ef0a8873cd954ac512a505/src/utils/huffman.c
-///
 
 const MAX_ALLOWED_CODE_LENGTH: usize = 15;
 const MAX_TABLE_BITS: u8 = 10;


### PR DESCRIPTION
Apply the two-pixels-at-once optimization for YUV conversion to RGBA codepath. RGB was already using it, so this is just a port of the same algorithm to RGBA.

Most of the code was written by @okaneco and posted in a comment on #13, I've just wired up the function they shared on godbolt.

I'm seeing a 7% end-to-end performance improvement on the sample from #119. With YUV->RGBA conversion accounting for 16% of the time, the function must have gotten roughly twice faster.