### PR TITLE
Avoid cloning frame

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -639,10 +639,8 @@ impl<R: BufRead + Seek> WebPDecoder<R> {
                 .chunks
                 .get(&WebPRiffChunk::VP8)
                 .ok_or(DecodingError::ChunkMissing)?;
-            // TODO: avoid cloning frame
-            let frame = Vp8Decoder::new(range_reader(&mut self.r, range.start..range.end)?)
-                .decode_frame()?
-                .clone();
+            let reader = range_reader(&mut self.r, range.start..range.end)?;
+            let frame = Vp8Decoder::decode_frame(reader)?;
             if u32::from(frame.width) != self.width || u32::from(frame.height) != self.height {
                 return Err(DecodingError::InconsistentImageSizes);
             }
@@ -746,8 +744,7 @@ impl<R: BufRead + Seek> WebPDecoder<R> {
         let (frame, frame_has_alpha): (Vec<u8>, bool) = match chunk {
             WebPRiffChunk::VP8 => {
                 let reader = (&mut self.r).take(chunk_size);
-                let mut vp8_decoder = Vp8Decoder::new(reader);
-                let raw_frame = vp8_decoder.decode_frame()?;
+                let raw_frame = Vp8Decoder::decode_frame(reader)?;
                 if raw_frame.width as u32 != frame_width || raw_frame.height as u32 != frame_height
                 {
                     return Err(DecodingError::InconsistentImageSizes);
@@ -781,8 +778,7 @@ impl<R: BufRead + Seek> WebPDecoder<R> {
                     return Err(DecodingError::ChunkHeaderInvalid(next_chunk.to_fourcc()));
                 }
 
-                let mut vp8_decoder = Vp8Decoder::new((&mut self.r).take(next_chunk_size));
-                let frame = vp8_decoder.decode_frame()?;
+                let frame = Vp8Decoder::decode_frame((&mut self.r).take(next_chunk_size))?;
 
                 let mut rgba_frame = vec![0; frame_width as usize * frame_height as usize * 4];
                 frame.fill_rgba(&mut rgba_frame);

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -749,7 +749,8 @@ impl<R: BufRead + Seek> WebPDecoder<R> {
             WebPRiffChunk::VP8 => {
                 let reader = (&mut self.r).take(chunk_size);
                 let raw_frame = Vp8Decoder::decode_frame(reader)?;
-                if raw_frame.width as u32 != frame_width || raw_frame.height as u32 != frame_height
+                if u32::from(raw_frame.width) != frame_width
+                    || u32::from(raw_frame.height) != frame_height
                 {
                     return Err(DecodingError::InconsistentImageSizes);
                 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -748,8 +748,7 @@ impl<R: BufRead + Seek> WebPDecoder<R> {
         let (frame, frame_has_alpha): (Vec<u8>, bool) = match chunk {
             WebPRiffChunk::VP8 => {
                 let reader = (&mut self.r).take(chunk_size);
-                let mut vp8_decoder = Vp8Decoder::new(reader);
-                let raw_frame = vp8_decoder.decode_frame()?;
+                let raw_frame = Vp8Decoder::decode_frame(reader)?;
                 if raw_frame.width as u32 != frame_width || raw_frame.height as u32 != frame_height
                 {
                     return Err(DecodingError::InconsistentImageSizes);

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -1090,7 +1090,7 @@ pub struct Vp8Decoder<R> {
 impl<R: Read> Vp8Decoder<R> {
     /// Create a new decoder.
     /// The reader must present a raw vp8 bitstream to the decoder
-    pub fn new(r: R) -> Vp8Decoder<R> {
+    fn new(r: R) -> Vp8Decoder<R> {
         let f = Frame::default();
         let s = Segment::default();
         let m = MacroBlock::default();
@@ -2172,7 +2172,12 @@ impl<R: Read> Vp8Decoder<R> {
     }
 
     /// Decodes the current frame
-    pub fn decode_frame(&mut self) -> Result<&Frame, DecodingError> {
+    pub fn decode_frame(r: R) -> Result<Frame, DecodingError> {
+        let decoder = Self::new(r);
+        decoder.decode_frame_()
+    }
+
+    fn decode_frame_(mut self) -> Result<Frame, DecodingError> {
         self.read_frame_header()?;
 
         for mby in 0..self.mbheight as usize {
@@ -2214,7 +2219,7 @@ impl<R: Read> Vp8Decoder<R> {
             }
         }
 
-        Ok(&self.frame)
+        Ok(self.frame)
     }
 }
 


### PR DESCRIPTION
Small and harmless optimization that improves performance by about 4%.

    Summary
      dwebp -noasm -nofancy Puente.webp ran
        1.13 ± 0.00 times faster than target/release/image-webp-runner Puente.webp
        1.18 ± 0.00 times faster than target/release/image-webp-runner-20250101 Puente.webp