### PR TITLE
Optimize `apply_color_indexing_transform` for table sizes over 16

### DIFF
--- a/src/lossless_transform.rs
+++ b/src/lossless_transform.rs
@@ -387,11 +387,12 @@ pub(crate) fn apply_color_indexing_transform(
     table_data: &[u8],
 ) {
     if table_size > 16 {
-        let mut table = table_data.chunks_exact(4).collect::<Vec<_>>();
-        table.resize(256, &[0; 4]);
+        let mut table: Vec<[u8; 4]> = table_data.chunks_exact(4).map(|c| TryInto::<[u8; 4]>::try_into(c).unwrap()).collect();
+        table.resize(256, [0; 4]);
+        let table: &[[u8; 4]; 256] = table.as_slice().try_into().unwrap();
 
         for pixel in image_data.chunks_exact_mut(4) {
-            pixel.copy_from_slice(table[pixel[1] as usize]);
+            pixel.copy_from_slice(&table[pixel[1] as usize]);
         }
     } else {
         let width_bits: u8 = if table_size <= 2 {

--- a/src/lossless_transform.rs
+++ b/src/lossless_transform.rs
@@ -387,8 +387,12 @@ pub(crate) fn apply_color_indexing_transform(
     table_data: &[u8],
 ) {
     if table_size > 16 {
-        // convert the table of colors into a Vec of color values that can be directly indexed, and that the compiler knows are always 4 bytes in size
-        let mut table: Vec<[u8; 4]> = table_data.chunks_exact(4).map(|c| TryInto::<[u8; 4]>::try_into(c).unwrap()).collect();
+        // convert the table of colors into a Vec of color values that can be directly indexed
+        let mut table: Vec<[u8; 4]> = table_data
+            .chunks_exact(4)
+            // convince the compiler that each chunk is 4 bytes long, important for optimizations in the loop below
+            .map(|c| TryInto::<[u8; 4]>::try_into(c).unwrap())
+            .collect();
         // pad the table to 256 values if it's smaller than that so we could index into it by u8 without bounds checks
         table.resize(256, [0; 4]);
         // convince the compiler that the length of the table is 256 to avoid bounds checks in the loop below

--- a/src/lossless_transform.rs
+++ b/src/lossless_transform.rs
@@ -387,8 +387,11 @@ pub(crate) fn apply_color_indexing_transform(
     table_data: &[u8],
 ) {
     if table_size > 16 {
+        // convert the table of colors into a Vec of color values that can be directly indexed, and that the compiler knows are always 4 bytes in size
         let mut table: Vec<[u8; 4]> = table_data.chunks_exact(4).map(|c| TryInto::<[u8; 4]>::try_into(c).unwrap()).collect();
+        // pad the table to 256 values if it's smaller than that so we could index into it by u8 without bounds checks
         table.resize(256, [0; 4]);
+        // convince the compiler that the length of the table is 256 to avoid bounds checks in the loop below
         let table: &[[u8; 4]; 256] = table.as_slice().try_into().unwrap();
 
         for pixel in image_data.chunks_exact_mut(4) {


### PR DESCRIPTION
Brings down the decode time for this indexed WebP I converted from PNG using GIMP from 36ms to 32ms. For reference `dwebp -noasm` is 30ms.

 [Exoplanet_Phase_Curve_(Diagram)_(01HK57P2YHV18MMV0RG5N7HY70).indexed.webp.zip](https://github.com/user-attachments/files/20556488/Exoplanet_Phase_Curve_.Diagram._.01HK57P2YHV18MMV0RG5N7HY70.indexed.webp.zip)

Resulting assembly:
Before: https://rust.godbolt.org/z/96v55T5TK
After: https://rust.godbolt.org/z/3M8zr8saM

Part of #131 but does not address the lower table sizes that the issue was originally about.