### PR TITLE
fix loop filter, probably

### DIFF
--- a/src/loop_filter.rs
+++ b/src/loop_filter.rs
@@ -68,6 +68,7 @@ fn should_filter(
         && diff(pixels[point + 3 * stride], pixels[point + 2 * stride]) <= interior_limit
         && diff(pixels[point + 2 * stride], pixels[point + stride]) <= interior_limit
         && diff(pixels[point + stride], pixels[point]) <= interior_limit
+        && diff(pixels[point - stride], pixels[point]) <= interior_limit
 }
 
 fn high_edge_variance(threshold: u8, pixels: &[u8], point: usize, stride: usize) -> bool {


### PR DESCRIPTION
This code seems to be comparing every pair of pixels separated by `stride` from `point - (4 * stride)` to `point + (3 * stride)` but the actual implementation is missing one of those comparisons.

I couldn't find the specification of this function in [VP8 loop filter spec](https://www.rfc-editor.org/rfc/rfc6386#section-15) so I don't know what the expected behavior actually is, but this single omission just seems very weird and probably unintentional.