### PR TITLE
Undo breaking loop filter, add a comment so that this doesn't happen again

### DIFF
--- a/src/loop_filter.rs
+++ b/src/loop_filter.rs
@@ -62,13 +62,15 @@ fn should_filter(
     stride: usize,
 ) -> bool {
     simple_threshold(i32::from(edge_limit), pixels, point, stride)
+        // this looks like an erroneous way to compute differences between 8 points, but isn't:
+        // there are actually only 6 diff comparisons required as per the spec:
+        // https://www.rfc-editor.org/rfc/rfc6386#section-20.6
         && diff(pixels[point - 4 * stride], pixels[point - 3 * stride]) <= interior_limit
         && diff(pixels[point - 3 * stride], pixels[point - 2 * stride]) <= interior_limit
         && diff(pixels[point - 2 * stride], pixels[point - stride]) <= interior_limit
         && diff(pixels[point + 3 * stride], pixels[point + 2 * stride]) <= interior_limit
         && diff(pixels[point + 2 * stride], pixels[point + stride]) <= interior_limit
         && diff(pixels[point + stride], pixels[point]) <= interior_limit
-        && diff(pixels[point - stride], pixels[point]) <= interior_limit
 }
 
 fn high_edge_variance(threshold: u8, pixels: &[u8], point: usize, stride: usize) -> bool {


### PR DESCRIPTION
As @okaneco [pointed out](https://github.com/image-rs/image-webp/pull/137#issuecomment-2942683458), the behavior as implemented is correct, if confusing.

This undoes the breakage I've introduced and adds a comment to avoid others (or future me) getting confused by this code.