### PR TITLE
Fix loop filter divergence from the spec

### DIFF
--- a/src/loop_filter.rs
+++ b/src/loop_filter.rs
@@ -103,7 +103,7 @@ pub(crate) fn subblock_filter(
 
         if !hv {
             pixels[point + stride] = s2u(u2s(pixels[point + stride]) - a);
-            pixels[point - 2 * stride] = s2u(u2s(pixels[point - 2 * stride]) - a);
+            pixels[point - 2 * stride] = s2u(u2s(pixels[point - 2 * stride]) + a);
         }
     }
 }


### PR DESCRIPTION
As per page 92 of rfc6386: https://www.rfc-editor.org/rfc/rfc6386#section-15.3

```c
   void subblock_filter(
       uint8 hev_threshold,     /* detect high edge variance */
       uint8 interior_limit,    /* possibly disable filter */
       uint8 edge_limit,
       cint8 *P3, cint8 *P2, int8 *P1, int8 *P0,   /* pixels before
                                                      edge */
       int8 *Q0, int8 *Q1, cint8 *Q2, cint8 *Q3    /* pixels after
                                                      edge */
   ) {
       cint8 p3 = u2s(*P3), p2 = u2s(*P2), p1 = u2s(*P1),
         p0 = u2s(*P0);
       cint8 q0 = u2s(*Q0), q1 = u2s(*Q1), q2 = u2s(*Q2),
         q3 = u2s(*Q3);

       if (filter_yes(interior_limit, edge_limit, q3, q2, q1, q0,
         p0, p1, p2, p3))
       {
           const int hv = hev(hev_threshold, p1, p0, q0, q1);

           cint8 a = (common_adjust(hv, P1, P0, Q0, Q1) + 1) >> 1;

           if (!hv) {
               *Q1 = s2u(q1 - a);
               *P1 = s2u(p1 + a);
           }
       }
   }
```

In practice this fixes divergences against imagemagick on these 11 images: [fixed_by_loop_filter_sign_flip.zip](https://github.com/user-attachments/files/20617903/fixed_by_loop_filter_sign_flip.zip)

I have also verified that it does not regress any images in my test corpus.

Part of #139, although it doesn't fix that issue entirely - some filter-shaped divergence on the included image still remains.