### PR TITLE
Allow reading malformed images with icc_profile set but no ICCP chunk

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -436,10 +436,11 @@ impl<R: BufRead + Seek> WebPDecoder<R> {
                 }
                 self.is_lossy = self.is_lossy || self.chunks.contains_key(&WebPRiffChunk::VP8);
 
+                // NOTE: We allow malformed images that have `info.icc_profile` set without a ICCP chunk,
+                // because this is relatively common.
                 if info.animation
                     && (!self.chunks.contains_key(&WebPRiffChunk::ANIM)
                         || !self.chunks.contains_key(&WebPRiffChunk::ANMF))
-                    || info.icc_profile && !self.chunks.contains_key(&WebPRiffChunk::ICCP)
                     || info.exif_metadata && !self.chunks.contains_key(&WebPRiffChunk::EXIF)
                     || info.xmp_metadata && !self.chunks.contains_key(&WebPRiffChunk::XMP)
                     || !info.animation

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -12,6 +12,7 @@ pub(crate) struct WebPExtendedInfo {
     pub(crate) canvas_width: u32,
     pub(crate) canvas_height: u32,
 
+    #[allow(unused)]
     pub(crate) icc_profile: bool,
     pub(crate) exif_metadata: bool,
     pub(crate) xmp_metadata: bool,


### PR DESCRIPTION
I ran this image decoder over a large set of webp images extacted from the web. I found that a decent number of images cannot be read by this decoder, even though PIL or MacOS image viewer read them fine. It turns out all these are malformed images with icc_profile set to true, while there is no ICCP chunk. 

This change makes the decoder more forgiving and still allows decoding those images.