### PR TITLE
Fix border issue with chroma when decoding final macroblock 

### DIFF
--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -2324,8 +2324,8 @@ fn set_chroma_border(
     mbx: usize,
 ) {
     let stride = 1usize + 8;
-    // top left
-    left_border[0] = chroma_block[0];
+    // top left is top right of previous chroma block
+    left_border[0] = chroma_block[8];
 
     // left border
     for (i, left) in left_border[1..][..8].iter_mut().enumerate() {

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -2271,7 +2271,12 @@ fn create_border_luma(mbx: usize, mby: usize, mbw: usize, top: &[u8], left: &[u8
 
 const CHROMA_BLOCK_SIZE: usize = (8 + 1) * (8 + 1);
 // creates the left and top border for chroma prediction
-fn create_border_chroma(mbx: usize, mby: usize, top: &[u8], left: &[u8]) -> [u8; CHROMA_BLOCK_SIZE] {
+fn create_border_chroma(
+    mbx: usize,
+    mby: usize,
+    top: &[u8],
+    left: &[u8],
+) -> [u8; CHROMA_BLOCK_SIZE] {
     let stride: usize = 1usize + 8;
     let mut chroma_block = [0u8; CHROMA_BLOCK_SIZE];
 
@@ -2312,7 +2317,12 @@ fn create_border_chroma(mbx: usize, mby: usize, top: &[u8], left: &[u8]) -> [u8;
 }
 
 // set border
-fn set_chroma_border(left_border: &mut [u8], top_border: &mut [u8], chroma_block: &[u8], mbx: usize) {
+fn set_chroma_border(
+    left_border: &mut [u8],
+    top_border: &mut [u8],
+    chroma_block: &[u8],
+    mbx: usize,
+) {
     let stride = 1usize + 8;
     // top left
     left_border[0] = chroma_block[0];
@@ -2328,7 +2338,7 @@ fn set_chroma_border(left_border: &mut [u8], top_border: &mut [u8], chroma_block
     {
         *top = w;
     }
-} 
+}
 
 fn avg3(left: u8, this: u8, right: u8) -> u8 {
     let avg = (u16::from(left) + 2 * u16::from(this) + u16::from(right) + 2) >> 2;


### PR DESCRIPTION
Fixes #115. 
The issue there is that for chroma(but not luma) we lookup the top and left border pixels from the existing frame that's decoded, however when the image isn't a nice multiple of the macroblock size (the image in the issue is 24x24 and a macroblock is 16x16) then it can't lookup the extra pixels since they don't exist so instead it just uses the default value as if it were on the top or left of the image. This is incorrect, it should instead still maintain the border from the previous macroblock even if there's no image there.

Have basically just copied the way we do it for the luma border but scaled down for chroma, the logic is also simpler since chroma doesn't have the extra 4 pixels to the right.

Image decoded with this change:
![image](https://github.com/user-attachments/assets/f036d3d1-6d34-46a0-a850-95a88e5441df)
