### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+### Version 0.2.3
+
+Changes:
+ - Do not reject images with ICC profile bit set but missing ICCP chunk (#143)
+
+Bug Fixes:
+ - Fixed a bug that caused the last chroma macroblock in the image to be sometimes decoded incorrectly (#144)
+
 ### Version 0.2.2
 
 Changes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image-webp"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.80.1"


### PR DESCRIPTION
Ships bug fixes to users. And with that we're down to 0 known decoding bugs!