### PR TITLE
Fix a few loop filtering issues to match libwebp output

### DIFF
--- a/src/loop_filter.rs
+++ b/src/loop_filter.rs
@@ -19,11 +19,7 @@ fn s2u(val: i32) -> u8 {
 
 #[inline]
 const fn diff(val1: u8, val2: u8) -> u8 {
-    if val1 > val2 {
-        val1 - val2
-    } else {
-        val2 - val1
-    }
+    u8::abs_diff(val1, val2)
 }
 
 //15.2

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -822,8 +822,14 @@ impl Frame {
 
         let buffer_width = usize::from(self.buffer_width());
 
-        let u_row_twice_iter = self.ubuf.chunks_exact(buffer_width / 2).flat_map(|n| std::iter::repeat(n).take(2));
-        let v_row_twice_iter = self.vbuf.chunks_exact(buffer_width / 2).flat_map(|n| std::iter::repeat(n).take(2));
+        let u_row_twice_iter = self
+            .ubuf
+            .chunks_exact(buffer_width / 2)
+            .flat_map(|n| std::iter::repeat(n).take(2));
+        let v_row_twice_iter = self
+            .vbuf
+            .chunks_exact(buffer_width / 2)
+            .flat_map(|n| std::iter::repeat(n).take(2));
 
         for (((row, y_row), u_row), v_row) in buf
             .chunks_exact_mut(usize::from(self.width) * BPP)
@@ -895,8 +901,14 @@ impl Frame {
 
         let buffer_width = usize::from(self.buffer_width());
 
-        let u_row_twice_iter = self.ubuf.chunks_exact(buffer_width / 2).flat_map(|n| std::iter::repeat(n).take(2));
-        let v_row_twice_iter = self.vbuf.chunks_exact(buffer_width / 2).flat_map(|n| std::iter::repeat(n).take(2));
+        let u_row_twice_iter = self
+            .ubuf
+            .chunks_exact(buffer_width / 2)
+            .flat_map(|n| std::iter::repeat(n).take(2));
+        let v_row_twice_iter = self
+            .vbuf
+            .chunks_exact(buffer_width / 2)
+            .flat_map(|n| std::iter::repeat(n).take(2));
 
         for (((row, y_row), u_row), v_row) in buf
             .chunks_exact_mut(usize::from(self.width) * BPP)

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -94,7 +94,7 @@ fn reference_test(file: &str) {
             .filter(|(a, b)| a != b)
             .count();
         let percentage_different = 100 * num_bytes_different / data.len();
-        if percentage_different >= 10 {
+        if percentage_different >= 1 {
             save_image(
                 &data,
                 file,
@@ -104,7 +104,7 @@ fn reference_test(file: &str) {
                 height,
             );
         }
-        assert!(percentage_different < 10, "More than 10% of pixels differ");
+        assert!(percentage_different < 1, "More than 1% of pixels differ");
     }
 
     // If the file is animated, then check all frames.
@@ -133,10 +133,10 @@ fn reference_test(file: &str) {
                     .filter(|(a, b)| a != b)
                     .count();
                 let percentage_different = 100 * num_bytes_different / data.len();
-                if percentage_different >= 10 {
+                if percentage_different >= 1 {
                     save_image(&data, file, Some(i), decoder.has_alpha(), width, height);
                 }
-                assert!(percentage_different < 10, "More than 10% of pixels differ");
+                assert!(percentage_different < 1, "More than 1% of pixels differ");
             } else if data != reference_data {
                 save_image(&data, file, Some(i), decoder.has_alpha(), width, height);
                 panic!("Pixel mismatch")


### PR DESCRIPTION
Fixes these three issues with the loop filtering so that #146 shouldn't have discrepancies:
1. The filtering threshold level is set incorrectly in some cases; doesn't match the spec
2. We don't check correctly for if we should do subblock filtering on a macroblock by checking if there exists a non-zero dct
3. Results don't match for some of the final macroblocks since the yuv buffers don't contain all the data on the end of the macroblocks so would cause issues. Therefore we have to expand the yuv buffers so they always cover macroblocks and do loop filtering for all the macroblocks evenly. The rgb buffers should still be filled correctly because of the way we zip the iterators.

Tested with the image in the gallery mentioned in the issue: reftest_gallery2_1_webp_a by decoding with libwebp -nofancy to a png, loading both the png and webp and comparing all the pixels which matched exactly. Will need to check some more images to see if there's any remaining discrepancies though.
