### PR TITLE
Fix further loop filtering issues

### DIFF
--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -86,15 +86,12 @@ fn reference_test(file: &str) {
     } else {
         // NOTE: WebP lossy images are stored in YUV format. The conversion to RGB is not precisely
         // defined, but we currently attempt to match the dwebp's "-nofancy" conversion option.
-        //
-        // TODO: Investigate why we don't get bit exact output for all pixels.
         let num_bytes_different = data
             .iter()
             .zip(reference_data.iter())
             .filter(|(a, b)| a != b)
             .count();
-        let percentage_different = 100 * num_bytes_different / data.len();
-        if percentage_different >= 1 {
+        if num_bytes_different > 0 {
             save_image(
                 &data,
                 file,
@@ -104,7 +101,7 @@ fn reference_test(file: &str) {
                 height,
             );
         }
-        assert!(percentage_different < 1, "More than 1% of pixels differ");
+        assert_eq!(num_bytes_different, 0, "Pixel mismatch");
     }
 
     // If the file is animated, then check all frames.
@@ -132,11 +129,10 @@ fn reference_test(file: &str) {
                     .zip(reference_data.iter())
                     .filter(|(a, b)| a != b)
                     .count();
-                let percentage_different = 100 * num_bytes_different / data.len();
-                if percentage_different >= 1 {
+                if num_bytes_different > 0 {
                     save_image(&data, file, Some(i), decoder.has_alpha(), width, height);
                 }
-                assert!(percentage_different < 1, "More than 1% of pixels differ");
+                assert_eq!(num_bytes_different, 0, "Pixel mismatch");
             } else if data != reference_data {
                 save_image(&data, file, Some(i), decoder.has_alpha(), width, height);
                 panic!("Pixel mismatch")


### PR DESCRIPTION
From #148 a few images were still failing to match the libwebp output precisely so investigated and found 2 further issues:
1. From the spec: https://datatracker.ietf.org/doc/html/rfc6386#section-15 
`Note carefully that loop filtering must be skipped entirely if
   loop_filter_level at either the frame header level or macroblock
   override level is 0.  In no case should the loop filter be run with a
   value of 0; it should instead be skipped.`
We are currently only checking if the final loop filter value is set to 0 then we skip loop filtering but if the frame has loop filter level set to 0 we should skip altogether. Therefore just return early if we detect that.
2. We're not actually using the loop filter adjustments decoded in the frame header. The spec is a bit confusing here so just tried to match libwebp where if it's enabled we just add the first value. https://github.com/webmproject/libwebp/blob/85e098e58d3fb89fee93b09c6c4515dbc4593c46/src/dec/frame_dec.c#L295C1-L300C10
edit: checked the spec's implementation and now it makes sense, we only use the first value since it matches the first frame of the vp8

After these changes, those images that were not matching now do in my local tests, so change the decoder tests to match exactly.