### PR TITLE
Improve performance of horizontal loop filtering

### DIFF
--- a/src/loop_filter.rs
+++ b/src/loop_filter.rs
@@ -22,8 +22,10 @@ const fn diff(val1: u8, val2: u8) -> u8 {
     u8::abs_diff(val1, val2)
 }
 
-//15.2
-fn common_adjust(use_outer_taps: bool, pixels: &mut [u8], point: usize, stride: usize) -> i32 {
+/// Used in both the simple and normal filters described in 15.2 and 15.3
+///
+/// Adjusts the 2 middle pixels in a vertical loop filter
+fn common_adjust_vertical(use_outer_taps: bool, pixels: &mut [u8], point: usize, stride: usize) -> i32 {
     let p1 = u2s(pixels[point - 2 * stride]);
     let p0 = u2s(pixels[point - stride]);
     let q0 = u2s(pixels[point]);
@@ -32,11 +34,11 @@ fn common_adjust(use_outer_taps: bool, pixels: &mut [u8], point: usize, stride: 
     //value for the outer 2 pixels
     let outer = if use_outer_taps { c(p1 - q1) } else { 0 };
 
-    let mut a = c(outer + 3 * (q0 - p0));
+    let a = c(outer + 3 * (q0 - p0));
 
     let b = (c(a + 3)) >> 3;
 
-    a = (c(a + 4)) >> 3;
+    let a = (c(a + 4)) >> 3;
 
     pixels[point] = s2u(q0 - a);
     pixels[point - stride] = s2u(p0 + b);
@@ -44,20 +46,52 @@ fn common_adjust(use_outer_taps: bool, pixels: &mut [u8], point: usize, stride: 
     a
 }
 
-fn simple_threshold(filter_limit: i32, pixels: &[u8], point: usize, stride: usize) -> bool {
+/// Used in both the simple and normal filters described in 15.2 and 15.3
+///
+/// Adjusts the 2 middle pixels in a horizontal loop filter
+fn common_adjust_horizontal(use_outer_taps: bool, pixels: &mut [u8]) -> i32 {
+    let p1 = u2s(pixels[2]);
+    let p0 = u2s(pixels[3]);
+    let q0 = u2s(pixels[4]);
+    let q1 = u2s(pixels[5]);
+
+    //value for the outer 2 pixels
+    let outer = if use_outer_taps { c(p1 - q1) } else { 0 };
+
+    let a = c(outer + 3 * (q0 - p0));
+
+    let b = (c(a + 3)) >> 3;
+
+    let a = (c(a + 4)) >> 3;
+
+    pixels[4] = s2u(q0 - a);
+    pixels[3] = s2u(p0 + b);
+
+    a
+}
+
+#[inline]
+fn simple_threshold_vertical(filter_limit: i32, pixels: &[u8], point: usize, stride: usize) -> bool {
     i32::from(diff(pixels[point - stride], pixels[point])) * 2
         + i32::from(diff(pixels[point - 2 * stride], pixels[point + stride])) / 2
         <= filter_limit
 }
 
-fn should_filter(
+#[inline]
+fn simple_threshold_horizontal(filter_limit: i32, pixels: &[u8]) -> bool {
+    i32::from(diff(pixels[3], pixels[4])) * 2
+        + i32::from(diff(pixels[2], pixels[5])) / 2
+        <= filter_limit
+}
+
+fn should_filter_vertical(
     interior_limit: u8,
     edge_limit: u8,
     pixels: &[u8],
     point: usize,
     stride: usize,
 ) -> bool {
-    simple_threshold(i32::from(edge_limit), pixels, point, stride)
+    simple_threshold_vertical(i32::from(edge_limit), pixels, point, stride)
         // this looks like an erroneous way to compute differences between 8 points, but isn't:
         // there are actually only 6 diff comparisons required as per the spec:
         // https://www.rfc-editor.org/rfc/rfc6386#section-20.6
@@ -69,22 +103,57 @@ fn should_filter(
         && diff(pixels[point + stride], pixels[point]) <= interior_limit
 }
 
-fn high_edge_variance(threshold: u8, pixels: &[u8], point: usize, stride: usize) -> bool {
+fn should_filter_horizontal(
+    interior_limit: u8,
+    edge_limit: u8,
+    pixels: &[u8],
+) -> bool {
+    simple_threshold_horizontal(i32::from(edge_limit), pixels)
+        // this looks like an erroneous way to compute differences between 8 points, but isn't:
+        // there are actually only 6 diff comparisons required as per the spec:
+        // https://www.rfc-editor.org/rfc/rfc6386#section-20.6
+        && diff(pixels[0], pixels[1]) <= interior_limit
+        && diff(pixels[1], pixels[2]) <= interior_limit
+        && diff(pixels[2], pixels[3]) <= interior_limit
+        && diff(pixels[7], pixels[6]) <= interior_limit
+        && diff(pixels[6], pixels[5]) <= interior_limit
+        && diff(pixels[5], pixels[4]) <= interior_limit
+}
+
+#[inline]
+fn high_edge_variance_vertical(threshold: u8, pixels: &[u8], point: usize, stride: usize) -> bool {
     diff(pixels[point - 2 * stride], pixels[point - stride]) > threshold
         || diff(pixels[point + stride], pixels[point]) > threshold
 }
 
-//simple filter
-//effects 4 pixels on an edge(2 each side)
-pub(crate) fn simple_segment(edge_limit: u8, pixels: &mut [u8], point: usize, stride: usize) {
-    if simple_threshold(i32::from(edge_limit), pixels, point, stride) {
-        common_adjust(true, pixels, point, stride);
+#[inline]
+fn high_edge_variance_horizontal(threshold: u8, pixels: &[u8]) -> bool {
+    diff(pixels[2], pixels[3]) > threshold
+        || diff(pixels[5], pixels[4]) > threshold
+}
+
+/// Part of the simple filter described in 15.2 in the specification
+/// 
+/// Affects 4 pixels on an edge(2 each side)
+pub(crate) fn simple_segment_vertical(edge_limit: u8, pixels: &mut [u8], point: usize, stride: usize) {
+    if simple_threshold_vertical(i32::from(edge_limit), pixels, point, stride) {
+        common_adjust_vertical(true, pixels, point, stride);
     }
 }
 
-//normal filter
-//works on the 8 pixels on the edges between subblocks inside a macroblock
-pub(crate) fn subblock_filter(
+/// Part of the simple filter described in 15.2 in the specification
+/// 
+/// Affects 4 pixels on an edge(2 each side)
+pub(crate) fn simple_segment_horizontal(edge_limit: u8, pixels: &mut [u8]) {
+    if simple_threshold_horizontal(i32::from(edge_limit), pixels) {
+        common_adjust_horizontal(true, pixels);
+    }
+}
+
+/// Part of the normal filter described in 15.3 in the specification
+/// 
+/// Filters on the 8 pixels on the edges between subblocks inside a macroblock
+pub(crate) fn subblock_filter_vertical(
     hev_threshold: u8,
     interior_limit: u8,
     edge_limit: u8,
@@ -92,10 +161,10 @@ pub(crate) fn subblock_filter(
     point: usize,
     stride: usize,
 ) {
-    if should_filter(interior_limit, edge_limit, pixels, point, stride) {
-        let hv = high_edge_variance(hev_threshold, pixels, point, stride);
-
-        let a = (common_adjust(hv, pixels, point, stride) + 1) >> 1;
+    if should_filter_vertical(interior_limit, edge_limit, pixels, point, stride) {
+        let hv = high_edge_variance_vertical(hev_threshold, pixels, point, stride);
+        
+        let a = (common_adjust_vertical(hv, pixels, point, stride) + 1) >> 1;
 
         if !hv {
             pixels[point + stride] = s2u(u2s(pixels[point + stride]) - a);
@@ -104,9 +173,32 @@ pub(crate) fn subblock_filter(
     }
 }
 
-//normal filter
-//works on the 8 pixels on the edges between macroblocks
-pub(crate) fn macroblock_filter(
+/// Part of the normal filter described in 15.3 in the specification
+/// 
+/// Filters on the 8 pixels on the edges between subblocks inside a macroblock
+pub(crate) fn subblock_filter_horizontal(
+    hev_threshold: u8,
+    interior_limit: u8,
+    edge_limit: u8,
+    pixels: &mut [u8],
+) {
+    if should_filter_horizontal(interior_limit, edge_limit, pixels) {
+        let hv = high_edge_variance_horizontal(hev_threshold, pixels);
+        
+        let a = (common_adjust_horizontal(hv, pixels) + 1) >> 1;
+
+        if !hv {
+            pixels[5] = s2u(u2s(pixels[5]) - a);
+            pixels[2] = s2u(u2s(pixels[2]) + a);
+        }
+    }
+}
+
+/// Part of the normal filter described in 15.3 in the specification
+/// 
+/// Filters on the 8 pixels on the vertical edges between macroblocks\
+/// The point passed in must be the first vertical pixel on the bottom macroblock
+pub(crate) fn macroblock_filter_vertical(
     hev_threshold: u8,
     interior_limit: u8,
     edge_limit: u8,
@@ -114,31 +206,222 @@ pub(crate) fn macroblock_filter(
     point: usize,
     stride: usize,
 ) {
-    let mut spixels = [0i32; 8];
-    for i in 0..8 {
-        spixels[i] = u2s(pixels[point + i * stride - 4 * stride]);
+    if should_filter_vertical(interior_limit, edge_limit, pixels, point, stride) {
+        if !high_edge_variance_vertical(hev_threshold, pixels, point, stride) {
+            // p0-3 are the pixels on the left macroblock from right to left
+            let p2 = u2s(pixels[point - 3 * stride]);
+            let p1 = u2s(pixels[point - 2 * stride]);
+            let p0 = u2s(pixels[point - stride]);
+            // q0-3 are the pixels on the right macroblock from left to right
+            let q0 = u2s(pixels[point]);
+            let q1 = u2s(pixels[point + stride]);
+            let q2 = u2s(pixels[point + 2 * stride]);
+
+            let w = c(c(p1 - q1) + 3 * (q0 - p0));
+            
+            let a = c((27 * w + 63) >> 7);
+            
+            pixels[point] = s2u(q0 - a);
+            pixels[point - stride] = s2u(p0 + a);
+            
+            let a = c((18 * w + 63) >> 7);
+            
+            pixels[point + stride] = s2u(q1 - a);
+            pixels[point - 2 * stride] = s2u(p1 + a);
+            
+            let a = c((9 * w + 63) >> 7);
+            
+            pixels[point + 2 * stride] = s2u(q2 - a);
+            pixels[point - 3 * stride] = s2u(p2 + a);
+        } else {
+            common_adjust_vertical(true, pixels, point, stride);
+        }
+    }
+}
+
+/// Part of the normal filter described in 15.3 in the specification
+/// 
+/// Filters on the 8 pixels on the horizontal edges between macroblocks\
+/// The pixels passed in must be a slice containing the 4 pixels on each macroblock
+pub(crate) fn macroblock_filter_horizontal(
+    hev_threshold: u8,
+    interior_limit: u8,
+    edge_limit: u8,
+    pixels: &mut [u8],
+) {
+    assert!(pixels.len() >= 8);
+    if should_filter_horizontal(interior_limit, edge_limit, pixels) {
+        if !high_edge_variance_horizontal(hev_threshold, pixels) {
+            // p0-3 are the pixels on the left macroblock from right to left
+            let p2 = u2s(pixels[1]);
+            let p1 = u2s(pixels[2]);
+            let p0 = u2s(pixels[3]);
+            // q0-3 are the pixels on the right macroblock from left to right
+            let q0 = u2s(pixels[4]);
+            let q1 = u2s(pixels[5]);
+            let q2 = u2s(pixels[6]);
+
+            let w = c(c(p1 - q1) + 3 * (q0 - p0));
+            
+            let a = c((27 * w + 63) >> 7);
+            
+            pixels[4] = s2u(q0 - a);
+            pixels[3] = s2u(p0 + a);
+            
+            let a = c((18 * w + 63) >> 7);
+            
+            pixels[5] = s2u(q1 - a);
+            pixels[2] = s2u(p1 + a);
+            
+            let a = c((9 * w + 63) >> 7);
+            
+            pixels[6] = s2u(q2 - a);
+            pixels[1] = s2u(p2 + a);
+        } else {
+            common_adjust_horizontal(true, pixels);
+        }
+    }
+}
+
+#[cfg(all(test, feature = "_benchmarks"))]
+mod benches {
+    use super::*;
+    use test::{black_box, Bencher};
+
+    const TEST_DATA: [u8; 8 * 8] = [
+        177, 192, 179, 181, 185, 174, 186, 193,
+        185, 180, 175, 179, 175, 190, 189, 190,
+        185, 181, 177, 190, 190, 174, 176, 188,
+        192, 179, 186, 175, 190, 184, 190, 175,
+        175, 183, 183, 190, 187, 186, 176, 181,
+        183, 177, 182, 185, 183, 179, 178, 181,
+        191, 183, 188, 181, 180, 193, 185, 180,
+        177, 182, 177, 178, 179, 178, 191, 178,
+    ];
+
+    #[bench]
+    fn measure_horizontal_macroblock_filter(b: &mut Bencher) {
+
+        let hev_threshold = 5;
+        let interior_limit = 15;
+        let edge_limit = 15;
+
+        let mut data = TEST_DATA.clone();
+        let stride = 8;
+        
+        b.iter(|| {
+            for y in 0..8 {
+                black_box(macroblock_filter_horizontal(
+                    hev_threshold,
+                    interior_limit,
+                    edge_limit,
+                    &mut data[y * stride..][..8],
+                ));
+            }
+        });
     }
 
-    if should_filter(interior_limit, edge_limit, pixels, point, stride) {
-        if !high_edge_variance(hev_threshold, pixels, point, stride) {
-            let w = c(c(spixels[2] - spixels[5]) + 3 * (spixels[4] - spixels[3]));
+    #[bench]
+    fn measure_vertical_macroblock_filter(b: &mut Bencher) {
 
-            let mut a = c((27 * w + 63) >> 7);
+        let hev_threshold = 5;
+        let interior_limit = 15;
+        let edge_limit = 15;
 
-            pixels[point] = s2u(spixels[4] - a);
-            pixels[point - stride] = s2u(spixels[3] + a);
+        let mut data = TEST_DATA.clone();
+        let stride = 8;
+        
+        b.iter(|| {
+            for x in 0..8 {
+                black_box(macroblock_filter_vertical(
+                    hev_threshold,
+                    interior_limit,
+                    edge_limit,
+                    &mut data,
+                    4 * stride + x,
+                    stride,
+                ));
+            }
+        });
+    }
 
-            a = c((18 * w + 63) >> 7);
+    #[bench]
+    fn measure_horizontal_subblock_filter(b: &mut Bencher) {
+        let hev_threshold = 5;
+        let interior_limit = 15;
+        let edge_limit = 15;
 
-            pixels[point + stride] = s2u(spixels[5] - a);
-            pixels[point - 2 * stride] = s2u(spixels[2] + a);
+        let mut data = TEST_DATA.clone();
+        let stride = 8;
 
-            a = c((9 * w + 63) >> 7);
+        b.iter(|| {
+            for y in 0usize..8 {
+                black_box(subblock_filter_horizontal(
+                    hev_threshold,
+                    interior_limit,
+                    edge_limit,
+                    &mut data[y * stride..][..8],
+                ))
+            }
+        });
+    }
 
-            pixels[point + 2 * stride] = s2u(spixels[6] - a);
-            pixels[point - 3 * stride] = s2u(spixels[1] + a);
-        } else {
-            common_adjust(true, pixels, point, stride);
-        }
+    #[bench]
+    fn measure_vertical_subblock_filter(b: &mut Bencher) {
+        let hev_threshold = 5;
+        let interior_limit = 15;
+        let edge_limit = 15;
+
+        let mut data = TEST_DATA.clone();
+        let stride = 8;
+
+        b.iter(|| {
+            for x in 0..8 {
+                black_box(subblock_filter_vertical(
+                    hev_threshold,
+                    interior_limit,
+                    edge_limit,
+                    &mut data,
+                    4 * stride + x,
+                    stride,
+                ))
+            }
+        });
+    }
+
+    #[bench]
+    fn measure_simple_segment_horizontal_filter(b: &mut Bencher) {
+        let edge_limit = 15;
+
+        let mut data = TEST_DATA.clone();
+        let stride = 8;
+
+        b.iter(|| {
+            for y in 0usize..8 {
+                black_box(simple_segment_horizontal(
+                    edge_limit,
+                    &mut data[y * stride..][..8],
+                ))
+            }
+        });
+    }
+
+    #[bench]
+    fn measure_simple_segment_vertical_filter(b: &mut Bencher) {
+        let edge_limit = 15;
+
+        let mut data = TEST_DATA.clone();
+        let stride = 8;
+
+        b.iter(|| {
+            for x in 0usize..16 {
+                black_box(simple_segment_vertical(
+                    edge_limit,
+                    &mut data,
+                    4 * stride + x,
+                    stride,
+                ))
+            }
+        });
     }
 }

--- a/src/vp8.rs
+++ b/src/vp8.rs
@@ -1805,11 +1805,9 @@ impl<R: Read> Vp8Decoder<R> {
                         let y0 = mby * 16 + y;
                         let x0 = mbx * 16;
 
-                        loop_filter::simple_segment(
+                        loop_filter::simple_segment_horizontal(
                             mbedge_limit,
-                            &mut self.frame.ybuf[..],
-                            y0 * luma_w + x0,
-                            1,
+                            &mut self.frame.ybuf[y0 * luma_w + x0 - 4..][..8],
                         );
                     }
                 } else {
@@ -1817,13 +1815,11 @@ impl<R: Read> Vp8Decoder<R> {
                         let y0 = mby * 16 + y;
                         let x0 = mbx * 16;
 
-                        loop_filter::macroblock_filter(
+                        loop_filter::macroblock_filter_horizontal(
                             hev_threshold,
                             interior_limit,
                             mbedge_limit,
-                            &mut self.frame.ybuf[..],
-                            y0 * luma_w + x0,
-                            1,
+                            &mut self.frame.ybuf[y0 * luma_w + x0 - 4..][..8],
                         );
                     }
 
@@ -1831,21 +1827,17 @@ impl<R: Read> Vp8Decoder<R> {
                         let y0 = mby * 8 + y;
                         let x0 = mbx * 8;
 
-                        loop_filter::macroblock_filter(
+                        loop_filter::macroblock_filter_horizontal(
                             hev_threshold,
                             interior_limit,
                             mbedge_limit,
-                            &mut self.frame.ubuf[..],
-                            y0 * chroma_w + x0,
-                            1,
+                            &mut self.frame.ubuf[y0 * chroma_w + x0 - 4..][..8],
                         );
-                        loop_filter::macroblock_filter(
+                        loop_filter::macroblock_filter_horizontal(
                             hev_threshold,
                             interior_limit,
                             mbedge_limit,
-                            &mut self.frame.vbuf[..],
-                            y0 * chroma_w + x0,
-                            1,
+                            &mut self.frame.vbuf[y0 * chroma_w + x0 - 4..][..8],
                         );
                     }
                 }
@@ -1859,11 +1851,9 @@ impl<R: Read> Vp8Decoder<R> {
                             let y0 = mby * 16 + y;
                             let x0 = mbx * 16 + x;
 
-                            loop_filter::simple_segment(
+                            loop_filter::simple_segment_horizontal(
                                 sub_bedge_limit,
-                                &mut self.frame.ybuf[..],
-                                y0 * luma_w + x0,
-                                1,
+                                &mut self.frame.ybuf[y0 * luma_w + x0 - 4..][..8],
                             );
                         }
                     }
@@ -1873,13 +1863,11 @@ impl<R: Read> Vp8Decoder<R> {
                             let y0 = mby * 16 + y;
                             let x0 = mbx * 16 + x;
 
-                            loop_filter::subblock_filter(
+                            loop_filter::subblock_filter_horizontal(
                                 hev_threshold,
                                 interior_limit,
                                 sub_bedge_limit,
-                                &mut self.frame.ybuf[..],
-                                y0 * luma_w + x0,
-                                1,
+                                &mut self.frame.ybuf[y0 * luma_w + x0 - 4..][..8],
                             );
                         }
                     }
@@ -1888,22 +1876,18 @@ impl<R: Read> Vp8Decoder<R> {
                         let y0 = mby * 8 + y;
                         let x0 = mbx * 8 + 4;
 
-                        loop_filter::subblock_filter(
+                        loop_filter::subblock_filter_horizontal(
                             hev_threshold,
                             interior_limit,
                             sub_bedge_limit,
-                            &mut self.frame.ubuf[..],
-                            y0 * chroma_w + x0,
-                            1,
+                            &mut self.frame.ubuf[y0 * chroma_w + x0 - 4..][..8],
                         );
 
-                        loop_filter::subblock_filter(
+                        loop_filter::subblock_filter_horizontal(
                             hev_threshold,
                             interior_limit,
                             sub_bedge_limit,
-                            &mut self.frame.vbuf[..],
-                            y0 * chroma_w + x0,
-                            1,
+                            &mut self.frame.vbuf[y0 * chroma_w + x0 - 4..][..8],
                         );
                     }
                 }
@@ -1916,7 +1900,7 @@ impl<R: Read> Vp8Decoder<R> {
                         let y0 = mby * 16;
                         let x0 = mbx * 16 + x;
 
-                        loop_filter::simple_segment(
+                        loop_filter::simple_segment_vertical(
                             mbedge_limit,
                             &mut self.frame.ybuf[..],
                             y0 * luma_w + x0,
@@ -1929,7 +1913,7 @@ impl<R: Read> Vp8Decoder<R> {
                         let y0 = mby * 16;
                         let x0 = mbx * 16 + x;
 
-                        loop_filter::macroblock_filter(
+                        loop_filter::macroblock_filter_vertical(
                             hev_threshold,
                             interior_limit,
                             mbedge_limit,
@@ -1943,7 +1927,7 @@ impl<R: Read> Vp8Decoder<R> {
                         let y0 = mby * 8;
                         let x0 = mbx * 8 + x;
 
-                        loop_filter::macroblock_filter(
+                        loop_filter::macroblock_filter_vertical(
                             hev_threshold,
                             interior_limit,
                             mbedge_limit,
@@ -1951,7 +1935,7 @@ impl<R: Read> Vp8Decoder<R> {
                             y0 * chroma_w + x0,
                             chroma_w,
                         );
-                        loop_filter::macroblock_filter(
+                        loop_filter::macroblock_filter_vertical(
                             hev_threshold,
                             interior_limit,
                             mbedge_limit,
@@ -1971,7 +1955,7 @@ impl<R: Read> Vp8Decoder<R> {
                             let y0 = mby * 16 + y;
                             let x0 = mbx * 16 + x;
 
-                            loop_filter::simple_segment(
+                            loop_filter::simple_segment_vertical(
                                 sub_bedge_limit,
                                 &mut self.frame.ybuf[..],
                                 y0 * luma_w + x0,
@@ -1985,7 +1969,7 @@ impl<R: Read> Vp8Decoder<R> {
                             let y0 = mby * 16 + y;
                             let x0 = mbx * 16 + x;
 
-                            loop_filter::subblock_filter(
+                            loop_filter::subblock_filter_vertical(
                                 hev_threshold,
                                 interior_limit,
                                 sub_bedge_limit,
@@ -2000,7 +1984,7 @@ impl<R: Read> Vp8Decoder<R> {
                         let y0 = mby * 8 + 4;
                         let x0 = mbx * 8 + x;
 
-                        loop_filter::subblock_filter(
+                        loop_filter::subblock_filter_vertical(
                             hev_threshold,
                             interior_limit,
                             sub_bedge_limit,
@@ -2009,7 +1993,7 @@ impl<R: Read> Vp8Decoder<R> {
                             chroma_w,
                         );
 
-                        loop_filter::subblock_filter(
+                        loop_filter::subblock_filter_vertical(
                             hev_threshold,
                             interior_limit,
                             sub_bedge_limit,


### PR DESCRIPTION
Tried to implement the recommended changes in #136 by splitting out the vertical and horizontal loop filters, not totally sure what else I should be doing but these changes seem to help a bit from the benchmarks I added.
Improvements ranged from ~5-40% from before to after, the better improvements were on the horizontal filters (which makes sense).
Also cleaned up the comments a little, wondering if there's anything more we could do to improve `loop_filter::should_filter` 