### PR TITLE
Eliminate bounds checks from simple_threshold_horizontal()

### DIFF
--- a/src/loop_filter.rs
+++ b/src/loop_filter.rs
@@ -114,6 +114,7 @@ fn should_filter_vertical(
 }
 
 fn should_filter_horizontal(interior_limit: u8, edge_limit: u8, pixels: &[u8]) -> bool {
+    assert!(pixels.len() >= 8); // one bounds check up front eliminates all subsequent checks in this function
     simple_threshold_horizontal(i32::from(edge_limit), pixels)
         // this looks like an erroneous way to compute differences between 8 points, but isn't:
         // there are actually only 6 diff comparisons required as per the spec:

--- a/src/loop_filter.rs
+++ b/src/loop_filter.rs
@@ -89,7 +89,7 @@ fn simple_threshold_vertical(
 
 #[inline]
 fn simple_threshold_horizontal(filter_limit: i32, pixels: &[u8]) -> bool {
-    _ = pixels[5]; // one bounds check up front eliminates all subsequent checks in this function
+    assert!(pixels.len() >= 6); // one bounds check up front eliminates all subsequent checks in this function
     i32::from(diff(pixels[3], pixels[4])) * 2 + i32::from(diff(pixels[2], pixels[5])) / 2
         <= filter_limit
 }

--- a/src/loop_filter.rs
+++ b/src/loop_filter.rs
@@ -89,6 +89,7 @@ fn simple_threshold_vertical(
 
 #[inline]
 fn simple_threshold_horizontal(filter_limit: i32, pixels: &[u8]) -> bool {
+    _ = pixels[5]; // one bounds check up front eliminates all subsequent checks in this function
     i32::from(diff(pixels[3], pixels[4])) * 2 + i32::from(diff(pixels[2], pixels[5])) / 2
         <= filter_limit
 }


### PR DESCRIPTION
Bounds checks. Monkey see, monkey eliminate.

Before: https://rust.godbolt.org/z/G1dPcqMqT
After: https://rust.godbolt.org/z/Gs8WafKoK

This function is very hot according to the profile in #136