### PR TITLE
fix: VP8 frame dimensions not validated against ANMF frame size in the ALPH branch (AI)

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1021,62 +1021,15 @@ mod tests {
         // InconsistentImageSizes rather than panicking with an out-of-bounds slice
         // in fill_rgba. The ANMF declares a 1x1 frame but the VP8 keyframe decodes
         // to 2x2.
-        const VP8_2X2: [u8; 48] = [
-            0xd0, 0x01, 0x00, 0x9d, 0x01, 0x2a, 0x02, 0x00, 0x02, 0x00, 0x02, 0x00, 0x34, 0x25,
-            0xa0, 0x02, 0x74, 0xba, 0x01, 0xf8, 0x00, 0x03, 0xb0, 0x00, 0xfe, 0xf0, 0xc4, 0x0b,
-            0xff, 0x20, 0xb9, 0x61, 0x75, 0xc8, 0xd7, 0xff, 0x20, 0x3f, 0xe4, 0x07, 0xfc, 0x80,
-            0xff, 0xf8, 0xf2, 0x00, 0x00, 0x00,
+
+        let bytes = [
+            82, 73, 70, 70, 126, 0, 0, 0, 87, 69, 66, 80, 86, 80, 56, 88, 10, 0, 0, 0, 2, 0, 0, 0,
+            1, 0, 0, 1, 0, 0, 65, 78, 73, 77, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 65, 78, 77, 70, 82, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 65, 76, 80, 72, 2, 0, 0, 0, 0, 0,
+            86, 80, 56, 32, 48, 0, 0, 0, 208, 1, 0, 157, 1, 42, 2, 0, 2, 0, 2, 0, 52, 37, 160, 2,
+            116, 186, 1, 248, 0, 3, 176, 0, 254, 240, 196, 11, 255, 32, 185, 97, 117, 200, 215,
+            255, 32, 63, 228, 7, 252, 128, 255, 248, 242, 0, 0, 0,
         ];
-
-        fn chunk(fourcc: &[u8; 4], body: &[u8]) -> Vec<u8> {
-            let mut v = Vec::new();
-            v.extend_from_slice(fourcc);
-            v.extend_from_slice(&(body.len() as u32).to_le_bytes());
-            v.extend_from_slice(body);
-            if body.len() % 2 == 1 {
-                v.push(0);
-            }
-            v
-        }
-
-        fn le3(v: u32) -> [u8; 3] {
-            [
-                (v & 0xff) as u8,
-                ((v >> 8) & 0xff) as u8,
-                ((v >> 16) & 0xff) as u8,
-            ]
-        }
-
-        let mut vp8x = Vec::new();
-        vp8x.push(0x02); // flags: animation
-        vp8x.extend_from_slice(&le3(0)); // reserved
-        vp8x.extend_from_slice(&le3(2 - 1)); // canvas_width - 1 => 2
-        vp8x.extend_from_slice(&le3(2 - 1)); // canvas_height - 1 => 2
-
-        let mut anim = Vec::new();
-        anim.extend_from_slice(&[0, 0, 0, 0]);
-        anim.extend_from_slice(&0u16.to_le_bytes());
-
-        let mut anmf = Vec::new();
-        anmf.extend_from_slice(&le3(0)); // frame_x / 2
-        anmf.extend_from_slice(&le3(0)); // frame_y / 2
-        anmf.extend_from_slice(&le3(1 - 1)); // frame_width - 1 => 1
-        anmf.extend_from_slice(&le3(1 - 1)); // frame_height - 1 => 1
-        anmf.extend_from_slice(&le3(0)); // duration
-        anmf.push(0x00); // frame_info
-        anmf.extend_from_slice(&chunk(b"ALPH", &[0x00, 0x00]));
-        anmf.extend_from_slice(&chunk(b"VP8 ", &VP8_2X2));
-
-        let mut body = Vec::new();
-        body.extend_from_slice(b"WEBP");
-        body.extend_from_slice(&chunk(b"VP8X", &vp8x));
-        body.extend_from_slice(&chunk(b"ANIM", &anim));
-        body.extend_from_slice(&chunk(b"ANMF", &anmf));
-
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(b"RIFF");
-        bytes.extend_from_slice(&(body.len() as u32).to_le_bytes());
-        bytes.extend_from_slice(&body);
 
         let mut decoder = WebPDecoder::new(std::io::Cursor::new(bytes)).unwrap();
         assert!(decoder.is_animated());

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -830,6 +830,10 @@ impl<R: BufRead + Seek> WebPDecoder<R> {
                 }
 
                 let frame = Vp8Decoder::decode_frame((&mut self.r).take(next_chunk_size))?;
+                if u32::from(frame.width) != frame_width || u32::from(frame.height) != frame_height
+                {
+                    return Err(DecodingError::InconsistentImageSizes);
+                }
 
                 let mut rgba_frame = vec![0; frame_width as usize * frame_height as usize * 4];
                 frame.fill_rgba(&mut rgba_frame, self.webp_decode_options.lossy_upsampling);
@@ -1007,6 +1011,81 @@ mod tests {
         // All pixels are the same value
         let first_pixel = &data[..RGB_BPP];
         assert!(data.chunks_exact(3).all(|ch| ch.iter().eq(first_pixel)));
+    }
+
+    #[test]
+    fn read_frame_alph_vp8_dimension_mismatch() {
+        // Regression test: an animated extended WebP whose ANMF frame carries an
+        // ALPH sub-chunk followed by a VP8 sub-chunk whose decoded dimensions do
+        // not match the ANMF-declared frame size must be rejected with
+        // InconsistentImageSizes rather than panicking with an out-of-bounds slice
+        // in fill_rgba. The ANMF declares a 1x1 frame but the VP8 keyframe decodes
+        // to 2x2.
+        const VP8_2X2: [u8; 48] = [
+            0xd0, 0x01, 0x00, 0x9d, 0x01, 0x2a, 0x02, 0x00, 0x02, 0x00, 0x02, 0x00, 0x34, 0x25,
+            0xa0, 0x02, 0x74, 0xba, 0x01, 0xf8, 0x00, 0x03, 0xb0, 0x00, 0xfe, 0xf0, 0xc4, 0x0b,
+            0xff, 0x20, 0xb9, 0x61, 0x75, 0xc8, 0xd7, 0xff, 0x20, 0x3f, 0xe4, 0x07, 0xfc, 0x80,
+            0xff, 0xf8, 0xf2, 0x00, 0x00, 0x00,
+        ];
+
+        fn chunk(fourcc: &[u8; 4], body: &[u8]) -> Vec<u8> {
+            let mut v = Vec::new();
+            v.extend_from_slice(fourcc);
+            v.extend_from_slice(&(body.len() as u32).to_le_bytes());
+            v.extend_from_slice(body);
+            if body.len() % 2 == 1 {
+                v.push(0);
+            }
+            v
+        }
+
+        fn le3(v: u32) -> [u8; 3] {
+            [
+                (v & 0xff) as u8,
+                ((v >> 8) & 0xff) as u8,
+                ((v >> 16) & 0xff) as u8,
+            ]
+        }
+
+        let mut vp8x = Vec::new();
+        vp8x.push(0x02); // flags: animation
+        vp8x.extend_from_slice(&le3(0)); // reserved
+        vp8x.extend_from_slice(&le3(2 - 1)); // canvas_width - 1 => 2
+        vp8x.extend_from_slice(&le3(2 - 1)); // canvas_height - 1 => 2
+
+        let mut anim = Vec::new();
+        anim.extend_from_slice(&[0, 0, 0, 0]);
+        anim.extend_from_slice(&0u16.to_le_bytes());
+
+        let mut anmf = Vec::new();
+        anmf.extend_from_slice(&le3(0)); // frame_x / 2
+        anmf.extend_from_slice(&le3(0)); // frame_y / 2
+        anmf.extend_from_slice(&le3(1 - 1)); // frame_width - 1 => 1
+        anmf.extend_from_slice(&le3(1 - 1)); // frame_height - 1 => 1
+        anmf.extend_from_slice(&le3(0)); // duration
+        anmf.push(0x00); // frame_info
+        anmf.extend_from_slice(&chunk(b"ALPH", &[0x00, 0x00]));
+        anmf.extend_from_slice(&chunk(b"VP8 ", &VP8_2X2));
+
+        let mut body = Vec::new();
+        body.extend_from_slice(b"WEBP");
+        body.extend_from_slice(&chunk(b"VP8X", &vp8x));
+        body.extend_from_slice(&chunk(b"ANIM", &anim));
+        body.extend_from_slice(&chunk(b"ANMF", &anmf));
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&body);
+
+        let mut decoder = WebPDecoder::new(std::io::Cursor::new(bytes)).unwrap();
+        assert!(decoder.is_animated());
+        let buf_size = decoder.output_buffer_size().unwrap();
+        let mut buf = vec![0u8; buf_size];
+        assert!(matches!(
+            decoder.read_frame(&mut buf),
+            Err(DecodingError::InconsistentImageSizes)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Hi,

I am on the Cargo Team and was recently hired by the Rust Foundation to help triage AI discovered bugs. This bug was found with AI, namely [scrutineer](https://github.com/alpha-omega-security/scrutineer) and Fable. Except where specifically labeled this report was written by me.

Based on your email and https://github.com/image-rs/image/pull/3068, I decided not to handle this under embargo and just make a PR. The contents of the PR are also drafted by AI and reviewed by me. I am not precious about this code, if another fix process would work better Let me know.

For completeness here is the AI description of the problem:
<details>

> In read_frame (src/decoder.rs:752) the ANMF header supplies frame_width/frame_height (lines 775-776), bounded to <=16384 and checked to fit within the canvas (lines 777-782). When the frame's first sub-chunk is ALPH, control enters the ALPH branch (line 814). There the code reads the alpha plane sized to the ANMF dims (read_alpha_chunk(.., frame_width as u16, frame_height as u16), line 822-823), then decodes the following VP8 sub-chunk with Vp8Decoder::decode_frame (line 832). Crucially, unlike the plain-VP8 branch (line 798-802: if raw_frame.width != frame_width ... return InconsistentImageSizes) and the still-image path (src/decoder.rs:700), this branch performs no check that the VP8-decoded frame.width/frame.height equal the ANMF frame_width/frame_height. It allocates rgba_frame = vec![0; frame_width*frame_height*4] (line 834, ANMF dims) and then calls frame.fill_rgba(&mut rgba_frame, ..) (line 835), which forwards self.width/self.height (the VP8 dims) into fill_rgb_buffer_fancy. That function slices let top_row_buffer = &mut buffer[..width * BPP] (src/lossy/yuv.rs:93) using the VP8 width. When the VP8 frame is larger than the ANMF-declared frame, width*BPP exceeds rgba_frame.len() and the slice index panics. (Had fill_rgba not panicked, the subsequent alpha loop at lines 837-853 indexes alpha_chunk.data[alpha_index]/rgba_frame[buffer_index] with VP8 dims against ANMF-sized buffers, an equivalent OOB.) The VP8 width/height are attacker-controlled 14-bit values inside the VP8 keyframe header, fully independent of the ANMF fields.

</details>